### PR TITLE
Fixes #5: Manage GPU

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,9 +57,15 @@ resource "google_compute_instance_template" "default" {
     var.metadata
   )}"
 
+  guest_accelerator {
+    type  = "${var.gpu_type}"
+    count = "${var.enable_gpu}"
+  }
+
   scheduling {
-    preemptible       = "${var.preemptible}"
-    automatic_restart = "${var.automatic_restart}"
+    preemptible         = "${var.preemptible}"
+    automatic_restart   = "${var.automatic_restart}"
+    on_host_maintenance = "${var.enable_gpu == 1 ? "TERMINATE" : "MIGRATE"}"
   }
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -309,3 +309,15 @@ variable ssh_fw_rule {
   description = "Whether or not the SSH Firewall Rule should be created"
   default     = true
 }
+
+variable enable_gpu {
+  type        = "string"
+  description = "Enable GPU"
+  default     = "0"
+}
+
+variable gpu_type {
+  type        = "string"
+  description = "GPU Type"
+  default     = "nvidia-tesla-t4"
+}


### PR DESCRIPTION
### Changes

* Adds new parameters for GPU type and GPU count.
* GPU count is set to 1 since we will only support 1.

### Configuration

```terraform
module "wowza-ig" {
  source                 = "/Users/abhi/Documents/GitHub/terraform-google-managed-instance-group"
  version                = "1.1.17"
  region                 = "${var.region}"
  [...]
  enable_gpu             = "${local.enable_gpu}"
  gpu_type               = "${var.gpu_type}"
}
```
```hcl
enable_gpu = 1
gpu_type = "nvidia-tesla-t4"
```

### Testing

* Ensure IG gets created with GPU attached to the template
* Ensure VM comes online with GPU attached and confirmed via `nvidia-smi` tool
