### PR TITLE
Fixes #3: Add scratch disks in Instance Group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -47,6 +47,11 @@ resource "google_compute_instance_template" "default" {
     mode         = "${var.mode}"
   }
 
+  disk {
+    disk_type = "local-ssd"
+    type      = "SCRATCH"
+  }
+
   service_account {
     email  = "${var.service_account_email}"
     scopes = ["${var.service_account_scopes}"]


### PR DESCRIPTION
### Changes

* Adds a scratch disk

### Testing

* Ensure SSD gets added in the VM
```bash
[adastidar@agd-js7-as1-p-jj14 ~]$ lsblk
NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINT
sda      8:0    0  100G  0 disk 
├─sda1   8:1    0  200M  0 part /boot/efi
└─sda2   8:2    0 99.8G  0 part /
sdb      8:16   0  375G  0 disk /var/lib/jenkins
```